### PR TITLE
Fix countdown to show finished events

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,11 +507,25 @@
           );
           const diff = spTarget - spNow;
 
+          // Calcula diferenca para o fim, se existir
+          let endDiff = null;
+          if (m.end) {
+            const end = new Date(m.end);
+            const spEnd = new Date(
+              end.toLocaleString("en-US", { timeZone: "America/Sao_Paulo" })
+            );
+            endDiff = spEnd - spNow;
+          }
+
           const el = document.getElementById(m.elementId);
           if (!el) return;
 
           if (diff <= 0) {
-            el.textContent = "Evento iniciado! 🚀";
+            if (!m.end || (endDiff !== null && endDiff <= 0)) {
+              el.textContent = "Evento encerrado! ✅";
+            } else {
+              el.textContent = "Evento iniciado! 🚀";
+            }
             el.classList.add("text-lg");
             return;
           }


### PR DESCRIPTION
## Summary
- handle milestones with end dates so countdown cards show `Evento encerrado! ✅` after the end passes
- show `Evento encerrado! ✅` immediately for deadlines without an explicit end

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68441be2f07083209ab5ae56d0eba9e7