### PR TITLE
Atualiza datas do cronograma CACD 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Cronograma CACD 2025 - Datas Cosmocrata</title>
+    <title>Cronograma CACD 2026 - Datas Cosmocrata</title>
 
     <!-- Primary Meta Tags -->
-    <meta name="title" content="Cronograma CACD 2025 - Datas Cosmocrata" />
-    <meta name="description" content="Datas e prazos para o CACD 2025" />
+    <meta name="title" content="Cronograma CACD 2026 - Datas Cosmocrata" />
+    <meta name="description" content="Datas e prazos para o CACD 2026" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://datas.cosmocrata.com.br/" />
-    <meta property="og:title" content="Cronograma CACD 2025" />
-    <meta property="og:description" content="Datas e prazos para o CACD 2025" />
+    <meta property="og:title" content="Cronograma CACD 2026" />
+    <meta property="og:description" content="Datas e prazos para o CACD 2026" />
     <meta
       property="og:image"
       content="https://datas.cosmocrata.com.br/datas_cacd.png"
@@ -22,10 +22,10 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content="https://datas.cosmocrata.com.br/" />
-    <meta property="twitter:title" content="Cronograma CACD 2025" />
+    <meta property="twitter:title" content="Cronograma CACD 2026" />
     <meta
       property="twitter:description"
-      content="Datas e prazos para o CACD 2025"
+      content="Datas e prazos para o CACD 2026"
     />
     <meta
       property="twitter:image"
@@ -103,7 +103,7 @@
             Cosmocrata CACD
           </h1>
           <p class="text-gray-700 text-lg max-w-2xl">
-            Datas e prazos para o CACD 2025.
+            Datas e prazos para o CACD 2026.
           </p>
           <p class="text-gray-600">
             Contribua assinando gratuitamente a nossa newsletter.
@@ -143,7 +143,7 @@
             clip-rule="evenodd"
           />
         </svg>
-        Cronograma CACD 2025
+        Cronograma CACD 2026
       </h1>
 
       <!-- Abas -->
@@ -181,85 +181,94 @@
       const milestones = [
         {
           title: "Inscrições",
-          start: "2025-05-19T10:00:00-03:00",
-          end: "2025-06-04T23:59:59-03:00",
+          start: "2026-02-04T10:00:00-03:00",
+          end: "2026-02-25T23:59:59-03:00",
         },
         {
           title: "Data limite para Pagamento da Inscrição",
-          start: "2025-06-27T23:59:59-03:00",
+          start: "2026-03-13T23:59:59-03:00",
         },
         {
           title: "Consulta local de prova",
-          start: "2025-07-11T18:00:00-03:00",
+          start: "2026-03-20T18:00:00-03:00",
         },
-        { title: "1ª Fase", start: "2025-07-20T08:30:00-03:00" },
+        { title: "1ª Fase", start: "2026-03-29T08:30:00-03:00" },
         {
           title: "Gabarito 1ª Fase",
-          start: "2025-07-22T18:00:00-03:00",
-          end: "2025-07-24T18:00:00-03:00",
+          start: "2026-03-30T19:00:00-03:00",
+          end: "2026-04-01T18:00:00-03:00",
         },
         {
           title: "Recursos 1ª Fase",
-          start: "2025-07-23T10:00:00-03:00",
-          end: "2025-07-24T18:00:00-03:00",
+          start: "2026-03-31T10:00:00-03:00",
+          end: "2026-04-01T18:00:00-03:00",
         },
         {
           title: "Resultado Final 1ª Fase",
-          start: "2025-08-13T18:00:00-03:00",
+          start: "2026-04-17T18:00:00-03:00",
         },
         {
           title: "Prova Português - Manhã (4h)",
-          start: "2025-08-23T08:00:00-03:00",
+          start: "2026-04-25T08:00:00-03:00",
         },
         {
           title: "Prova História do Brasil - Tarde (5h)",
-          start: "2025-08-23T14:00:00-03:00",
+          start: "2026-04-25T14:00:00-03:00",
         },
         {
           title: "Prova Inglês - Manhã (4h)",
-          start: "2025-08-24T08:00:00-03:00",
+          start: "2026-04-26T08:00:00-03:00",
         },
         {
           title: "Prova Geografia - Tarde (5h)",
-          start: "2025-08-24T14:00:00-03:00",
+          start: "2026-04-26T14:00:00-03:00",
         },
         {
           title: "Padrão preliminar 2ª fase - parte 1",
-          start: "2025-08-26T18:00:00-03:00",
+          start: "2026-04-27T18:00:00-03:00",
         },
         {
           title: "Recursos padrão 2ª fase - parte 1",
-          start: "2025-08-27T10:00:00-03:00",
-          end: "2025-08-29T18:00:00-03:00",
+          start: "2026-04-28T10:00:00-03:00",
+          end: "2026-04-30T18:00:00-03:00",
         },
         {
           title: "Prova Política Internacional - Manhã (5h)",
-          start: "2025-08-30T08:00:00-03:00",
+          start: "2026-05-02T08:00:00-03:00",
         },
         {
           title: "Prova Economia - Tarde (5h)",
-          start: "2025-08-30T15:00:00-03:00",
+          start: "2026-05-02T15:00:00-03:00",
         },
         {
           title: "Prova Direito - Manhã (5h)",
-          start: "2025-08-31T08:00:00-03:00",
+          start: "2026-05-03T08:00:00-03:00",
         },
         {
           title: "Prova Espanhol/Francês - Tarde (4h)",
-          start: "2025-08-31T15:00:00-03:00",
+          start: "2026-05-03T15:00:00-03:00",
         },
         {
           title: "Padrão preliminar 2ª fase - parte 2",
-          start: "2025-09-02T18:00:00-03:00",
+          start: "2026-05-04T18:00:00-03:00",
         },
         {
           title: "Recursos padrão 2ª fase - parte 2",
-          start: "2025-09-03T10:00:00-03:00",
-          end: "2025-09-05T18:00:00-03:00",
+          start: "2026-05-05T10:00:00-03:00",
+          end: "2026-05-07T18:00:00-03:00",
         },
         {
           title: "Resultado Provisório 2ª Fase",
-          start: "2025-09-23T18:00:00-03:00",
+          start: "2026-05-21T18:00:00-03:00",
+        },
+        {
+          title: "Recursos padrão 2ª fase - parte 2 (1)",
+          start: "2026-05-22T10:00:00-03:00",
+          end: "2026-05-24T18:00:00-03:00",
+        },
+        {
+          title: "Resultado final nas provas escritas da 2ª fase",
+          start: "2026-06-03T18:00:00-03:00",
         },
       ];
 
@@ -359,8 +368,53 @@
           annotations: {
             xaxis: [
               {
-                x: adjustToSaoPaulo("2025-05-01").getTime(),
-                x2: adjustToSaoPaulo("2025-06-01").getTime(),
+                x: adjustToSaoPaulo("2026-02-01").getTime(),
+                x2: adjustToSaoPaulo("2026-03-01").getTime(),
+                borderColor: "#c5c5c5",
+                label: {
+                  text: "Fevereiro",
+                  orientation: "horizontal",
+                  position: "top",
+                  offsetY: -25,
+                  style: {
+                    background: "#fff",
+                    padding: "0 4px",
+                  },
+                },
+              },
+              {
+                x: adjustToSaoPaulo("2026-03-01").getTime(),
+                x2: adjustToSaoPaulo("2026-04-01").getTime(),
+                borderColor: "#c5c5c5",
+                label: {
+                  text: "Março",
+                  orientation: "horizontal",
+                  position: "top",
+                  offsetY: -25,
+                  style: {
+                    background: "#fff",
+                    padding: "0 4px",
+                  },
+                },
+              },
+              {
+                x: adjustToSaoPaulo("2026-04-01").getTime(),
+                x2: adjustToSaoPaulo("2026-05-01").getTime(),
+                borderColor: "#c5c5c5",
+                label: {
+                  text: "Abril",
+                  orientation: "horizontal",
+                  position: "top",
+                  offsetY: -25,
+                  style: {
+                    background: "#fff",
+                    padding: "0 4px",
+                  },
+                },
+              },
+              {
+                x: adjustToSaoPaulo("2026-05-01").getTime(),
+                x2: adjustToSaoPaulo("2026-06-01").getTime(),
                 borderColor: "#c5c5c5",
                 label: {
                   text: "Maio",
@@ -374,56 +428,11 @@
                 },
               },
               {
-                x: adjustToSaoPaulo("2025-06-01").getTime(),
-                x2: adjustToSaoPaulo("2025-07-01").getTime(),
+                x: adjustToSaoPaulo("2026-06-01").getTime(),
+                x2: adjustToSaoPaulo("2026-07-01").getTime(),
                 borderColor: "#c5c5c5",
                 label: {
                   text: "Junho",
-                  orientation: "horizontal",
-                  position: "top",
-                  offsetY: -25,
-                  style: {
-                    background: "#fff",
-                    padding: "0 4px",
-                  },
-                },
-              },
-              {
-                x: adjustToSaoPaulo("2025-07-01").getTime(),
-                x2: adjustToSaoPaulo("2025-08-01").getTime(),
-                borderColor: "#c5c5c5",
-                label: {
-                  text: "Julho",
-                  orientation: "horizontal",
-                  position: "top",
-                  offsetY: -25,
-                  style: {
-                    background: "#fff",
-                    padding: "0 4px",
-                  },
-                },
-              },
-              {
-                x: adjustToSaoPaulo("2025-08-01").getTime(),
-                x2: adjustToSaoPaulo("2025-09-01").getTime(),
-                borderColor: "#c5c5c5",
-                label: {
-                  text: "Agosto",
-                  orientation: "horizontal",
-                  position: "top",
-                  offsetY: -25,
-                  style: {
-                    background: "#fff",
-                    padding: "0 4px",
-                  },
-                },
-              },
-              {
-                x: adjustToSaoPaulo("2025-09-01").getTime(),
-                x2: adjustToSaoPaulo("2025-10-01").getTime(),
-                borderColor: "#c5c5c5",
-                label: {
-                  text: "Setembro",
                   orientation: "horizontal",
                   position: "top",
                   offsetY: -25,


### PR DESCRIPTION
### Motivation
- Atualizar o site para exibir o cronograma do CACD 2026 com as novas datas e prazos fornecidos. 
- Incluir ajustes de prazos tanto da 1ª fase quanto da 2ª fase (gabaritos, recursos e resultados). 
- Manter o padrão de escrita e os horários atuais conforme o layout já existente no site.

### Description
- Atualiza título e metadados da página para 2026 (`<title>`, `meta` tags e textos de destaque). 
- Substitui o array `milestones` em `index.html` com as novas datas/hora de 2026 e adiciona os eventos extras da 2ª fase. 
- Ajusta as anotações mensais do gráfico Gantt para o intervalo fevereiro–junho de 2026. 
- Preserva a lógica de fuso horário (`America/Sao_Paulo`), contagem regressiva e renderização do Gantt.

### Testing
- Iniciado um servidor local com `python -m http.server 8000` para servir o arquivo atualizado (sucesso). 
- Capturada uma validação visual com Playwright usando um script Python que gerou a tela completa em `artifacts/cacd-2026.png` (sucesso). 
- Inspecionado o arquivo atualizado com `nl -ba index.html` para revisar o diff e confirmar as mudanças (sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bf0bb43388320b002b9118d9c353a)